### PR TITLE
set *errin* isTTY properly in package mode (-p)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1936,6 +1936,7 @@ void InitSystem (
       /*         SyLineEdit   = 1;
                  SyCTRD       = 1; */
         syBuf[2].fp = fileno(stdin);  syBuf[2].echo = fileno(stdout);
+        syBuf[2].isTTY = syBuf[0].isTTY;
         syBuf[3].fp = fileno(stdout);
         syWinPut( 0, "@p", "1." );
     }


### PR DESCRIPTION
When running in package mode (-p), as used by xgap, GAP
sets *errin* to be the same as *stdin*.  It should at the same
time set isTTY to be the same as for *stdin*.